### PR TITLE
do not auto destroy buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,13 @@ SimpleHandshake.prototype.send = function send (data, cb) {
 }
 
 SimpleHandshake.prototype.destroy = function () {
-  this._finish(null, null, function () {})
+  this.finished = true
+  this.waiting = false
+
+  // Should be sodium_memzero?
+  this._rx.fill(0)
+  this._tx.fill(0)
+  noise.destroy(this.state)
 }
 
 SimpleHandshake.prototype._finish = function _finish (err, msg, cb) {
@@ -120,13 +126,7 @@ SimpleHandshake.prototype._finish = function _finish (err, msg, cb) {
   self.onhandshake(self.state, ondone)
 
   function ondone (err) {
-    noise.destroy(self.state)
-
     cb(err, msg, self.split)
-
-    // Should be sodium_memzero?
-    self._rx.fill(0)
-    self._tx.fill(0)
   }
 }
 


### PR DESCRIPTION
Right now buffers are auto zerofilled after the last call to the callback of hs.send(,,, cb).
This can introduce subtle bugs incase the returned buffer is buffered in the same tick.

Using an explicit destroy step makes that easier to handle.

Needs docs and tests